### PR TITLE
fix(transport-quic): invalid value for max early data size

### DIFF
--- a/crates/ombrac-transport/src/quic/server.rs
+++ b/crates/ombrac-transport/src/quic/server.rs
@@ -90,7 +90,7 @@ impl Connection {
 
             if config.enable_zero_rtt {
                 tls_config.send_half_rtt_data = true;
-                tls_config.max_early_data_size = 64 * 1024;
+                tls_config.max_early_data_size = u32::MAX;
             }
 
             tls_config


### PR DESCRIPTION
QUIC sessions must set a max early data of 0 or 2^32-1