### PR TITLE
build: add script to generate ombrac client XCFramework

### DIFF
--- a/scripts/build_xcframework_ombrac_client.sh
+++ b/scripts/build_xcframework_ombrac_client.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+CRATE_NAME="ombrac-client"
+FRAMEWORK_NAME="OmbracClient"
+HEADER_NAME="ombrac_client.h"
+
+LIB_NAME="${CRATE_NAME//-/_}"
+CRATE_PATH="$PROJECT_ROOT/crates/$CRATE_NAME"
+OUTPUT_DIR="$PROJECT_ROOT/target/xcframework"
+BUILD_DIR="$PROJECT_ROOT/target/xcframework_build"
+HEADER_PATH="$CRATE_PATH/$HEADER_NAME"
+
+cd "$PROJECT_ROOT"
+
+echo "🚀 Starting XCFramework build for $FRAMEWORK_NAME..."
+echo "Project Root: $PROJECT_ROOT"
+
+rm -rf "$BUILD_DIR"
+rm -rf "$OUTPUT_DIR/$FRAMEWORK_NAME.xcframework"
+mkdir -p "$BUILD_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+
+IOS_ARM64="aarch64-apple-ios"
+SIM_ARM64="aarch64-apple-ios-sim"
+SIM_X86_64="x86_64-apple-ios"
+MACOS_ARM64="aarch64-apple-darwin"
+MACOS_X86_64="x86_64-apple-darwin"
+
+TARGETS=($IOS_ARM64 $SIM_ARM64 $SIM_X86_64 $MACOS_ARM64 $MACOS_X86_64)
+
+for TARGET in "${TARGETS[@]}"; do
+    echo "Building for $TARGET..."
+    rustup target add $TARGET
+    cargo build --release --features binary --target $TARGET -p $CRATE_NAME
+    mkdir -p "$BUILD_DIR/$TARGET"
+    cp "target/$TARGET/release/lib${LIB_NAME}.a" "$BUILD_DIR/$TARGET/"
+done
+
+echo "Creating universal library for iOS simulators..."
+mkdir -p "$BUILD_DIR/ios-sim-universal"
+lipo -create \
+    "$BUILD_DIR/$SIM_ARM64/lib${LIB_NAME}.a" \
+    "$BUILD_DIR/$SIM_X86_64/lib${LIB_NAME}.a" \
+    -output "$BUILD_DIR/ios-sim-universal/lib${LIB_NAME}.a"
+
+echo "Creating universal library for macOS..."
+mkdir -p "$BUILD_DIR/macos-universal"
+lipo -create \
+    "$BUILD_DIR/$MACOS_ARM64/lib${LIB_NAME}.a" \
+    "$BUILD_DIR/$MACOS_X86_64/lib${LIB_NAME}.a" \
+    -output "$BUILD_DIR/macos-universal/lib${LIB_NAME}.a"
+
+echo "Preparing header files and module map..."
+
+HEADERS_DIR="$BUILD_DIR/headers"
+mkdir -p "$HEADERS_DIR"
+
+if [ ! -f "$HEADER_PATH" ]; then
+    echo "❌ Header file not found at $HEADER_PATH"
+    exit 1
+fi
+cp "$HEADER_PATH" "$HEADERS_DIR/"
+
+cat > "$HEADERS_DIR/module.modulemap" <<EOL
+module $FRAMEWORK_NAME {
+    umbrella header "$HEADER_NAME"
+    export *
+}
+EOL
+
+echo "Creating XCFramework for iOS and macOS..."
+xcodebuild -create-xcframework \
+    -library "$BUILD_DIR/$IOS_ARM64/lib${LIB_NAME}.a" -headers "$HEADERS_DIR" \
+    -library "$BUILD_DIR/ios-sim-universal/lib${LIB_NAME}.a" -headers "$HEADERS_DIR" \
+    -library "$BUILD_DIR/macos-universal/lib${LIB_NAME}.a" -headers "$HEADERS_DIR" \
+    -output "$OUTPUT_DIR/$FRAMEWORK_NAME.xcframework"
+
+
+rm -rf "$BUILD_DIR"
+
+echo ""
+echo "✅ Successfully created $OUTPUT_DIR/$FRAMEWORK_NAME.xcframework"


### PR DESCRIPTION
This commit introduces a new shell script, `scripts/build_xcframework_ombrac_client.sh`, to automate the creation of an `OmbracClient.xcframework`.

The script performs the following steps:
- Builds the `ombrac-client` Rust crate for various Apple targets: iOS (arm64), iOS simulators (arm64, x86_64), and macOS (arm64, x86_64).
- Creates universal static libraries for iOS simulators and macOS using `lipo`.
- Prepares the necessary header file and a module map.
- Packages all platform-specific libraries and headers into a single `OmbracClient.xcframework` using `xcodebuild`.