### PR TITLE
refactor: Overhaul FFI logging and consolidate dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1829,6 +1829,7 @@ dependencies = [
 name = "ombrac-server"
 version = "0.6.0"
 dependencies = [
+ "arc-swap",
  "bincode",
  "blake3",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ arc-swap = { version = "1.7", default-features = false }
 ringbuf = { version = "0.4", default-features = false }
 crossbeam-queue = { version = "0.3", default-features = false }
 moka = { version = "0.12", default-features = false }
-serde_bytes = { version = "0.11", default-features = false }
 bincode = { version = "2", default-features = false }
 cbindgen = { version = "0.29", default-features = false }
 auto_impl = { version = "1.3", default-features = false }

--- a/README.md
+++ b/README.md
@@ -11,17 +11,8 @@
 [![Build Status][ci-badge]][ci-url]
 [![Build Status][release-badge]][release-url]
 
-## Architecture
-```
-+----------+      +-------------------+      +===============+      +---------------+      +-----------------+
-| Your App |----->|   Ombrac Client   |----->|   Encrypted   |----->| Ombrac Server |----->| Target Internet |
-|          |<-----| (SOCKS5/HTTP/TUN) |<-----| （QUIC/Other） |<-----|               |<-----|                 |
-+----------+      +-------------------+      +===============+      +---------------+      +-----------------+
-```
-
 ## Installation
 The easiest way to get started is to download the latest pre-compiled binary from the [Releases Page](https://github.com/ombrac/ombrac/releases).
-
 
 ### Homebrew (macOS & Linux)
 ```shell
@@ -62,8 +53,7 @@ ombrac-server \
   -l "[::]:443" \
   -k "your-secret-key" \
   --tls-cert "/path/to/your/cert.pem" \
-  --tls-key "/path/to/your/key.pem" \
-  --log-level INFO
+  --tls-key "/path/to/your/key.pem"
 ```
 
 - `-l`: The address to listen on.
@@ -75,8 +65,7 @@ ombrac-server \
 ombrac-client \
   -s "your-server:443" \
   -k "your-secret-key" \
-  --socks "127.0.0.1:1080" \
-  --log-level INFO
+  --socks "127.0.0.1:1080"
 ```
 
 - `-s`: The server address to connect to.  
@@ -140,8 +129,6 @@ Transport:
 
 Logging:
       --log-level <LEVEL>  Logging level (e.g., INFO, WARN, ERROR) [default: INFO]
-      --log-dir <PATH>     Path to the log directory
-      --log-prefix <STR>   Prefix for log file names (only used when log dir is specified)
 
 ```
 
@@ -184,8 +171,6 @@ Transport:
 
 Logging:
       --log-level <LEVEL>  Logging level (e.g., INFO, WARN, ERROR) [default: INFO]
-      --log-dir <PATH>     Path to the log directory
-      --log-prefix <STR>   Prefix for log file names (only used when log dir is specified)
 
 ```
 

--- a/crates/ombrac-client/Cargo.toml
+++ b/crates/ombrac-client/Cargo.toml
@@ -77,6 +77,7 @@ bytes = { workspace = true }
 blake3 = { workspace = true }
 bincode = { workspace = true }
 futures = { workspace = true }
+arc-swap = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 figment = { workspace = true, features = ["json"] }
@@ -89,7 +90,6 @@ tracing-appender = { workspace = true, optional = true}
 tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "registry"], optional = true }
 
 # endpoint
-arc-swap = { workspace = true }
 socks-lib = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
 hyper = { workspace = true, features = ["client", "server", "http1"], optional = true }

--- a/crates/ombrac-client/bin/main.rs
+++ b/crates/ombrac-client/bin/main.rs
@@ -9,6 +9,10 @@ fn main() {
         }
     };
 
+    // Initialize logging for the binary.
+    #[cfg(feature = "tracing")]
+    ombrac_client::logging::init_for_binary(&config.logging);
+
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()

--- a/crates/ombrac-client/ombrac_client.h
+++ b/crates/ombrac-client/ombrac_client.h
@@ -7,15 +7,8 @@
 
 /**
  * A type alias for the C-style callback function pointer.
- *
- * The `level` parameter is an integer representation of the log level:
- * - `0`: TRACE
- * - `1`: DEBUG
- * - `2`: INFO
- * - `3`: WARN
- * - `4`: ERROR
  */
-typedef void (*LogCallback)(int32_t level, const char *message, const char *target);
+typedef void (*LogCallback)(const char *message);
 
 /**
  * Initializes the logging system to use a C-style callback for log messages.
@@ -32,10 +25,9 @@ typedef void (*LogCallback)(int32_t level, const char *message, const char *targ
  * # Safety
  *
  * The provided `callback` function pointer must be valid and remain valid for
- * the lifetime of the program. This function is not thread-safe and should be
- * called only once during initialization.
+ * the lifetime of the program.
  */
-void ombrac_client_logging_init(LogCallback callback);
+void ombrac_client_set_log_callback(LogCallback callback);
 
 /**
  * Initializes and starts the service with a given JSON configuration.

--- a/crates/ombrac-client/src/config.rs
+++ b/crates/ombrac-client/src/config.rs
@@ -176,16 +176,6 @@ pub struct LoggingConfig {
     #[clap(long, help_heading = "Logging", value_name = "LEVEL")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log_level: Option<String>,
-
-    /// Path to the log directory
-    #[clap(long, value_name = "PATH", help_heading = "Logging")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub log_dir: Option<PathBuf>,
-
-    /// Prefix for log file names (only used when log dir is specified)
-    #[clap(long, value_name = "STR", help_heading = "Logging")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub log_prefix: Option<PathBuf>,
 }
 
 #[cfg(feature = "endpoint-tun")]
@@ -280,8 +270,6 @@ impl Default for LoggingConfig {
     fn default() -> Self {
         Self {
             log_level: Some("INFO".to_string()),
-            log_dir: None,
-            log_prefix: None,
         }
     }
 }

--- a/crates/ombrac-client/src/ffi.rs
+++ b/crates/ombrac-client/src/ffi.rs
@@ -9,7 +9,7 @@ use ombrac_macros::{error, info};
 
 use crate::config::{ConfigFile, ServiceConfig};
 #[cfg(feature = "tracing")]
-use crate::logging::{LogCallback, LoggingMode};
+use crate::logging::LogCallback;
 #[cfg(feature = "transport-quic")]
 use crate::service::QuicServiceBuilder;
 use crate::service::Service;
@@ -49,12 +49,11 @@ unsafe fn c_str_to_str<'a>(s: *const c_char) -> &'a str {
 /// # Safety
 ///
 /// The provided `callback` function pointer must be valid and remain valid for
-/// the lifetime of the program. This function is not thread-safe and should be
-/// called only once during initialization.
+/// the lifetime of the program.
 #[cfg(feature = "tracing")]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn ombrac_client_logging_init(callback: LogCallback) {
-    crate::logging::init(LoggingMode::Callback(callback));
+pub unsafe extern "C" fn ombrac_client_set_log_callback(callback: LogCallback) {
+    crate::logging::set_log_callback(Some(callback));
 }
 
 /// Initializes and starts the service with a given JSON configuration.
@@ -115,6 +114,9 @@ pub unsafe extern "C" fn ombrac_client_service_startup(config_json: *const c_cha
             return -1;
         }
     };
+
+    #[cfg(feature = "tracing")]
+    crate::logging::init_for_ffi(&service_config.logging);
 
     let runtime = match Builder::new_multi_thread().enable_all().build() {
         Ok(rt) => rt,
@@ -199,6 +201,6 @@ pub extern "C" fn ombrac_client_service_shutdown() -> i32 {
 /// string is managed by the library and should not be freed by the caller.
 #[unsafe(no_mangle)]
 pub extern "C" fn ombrac_client_get_version() -> *const c_char {
-    const VERSION_WITH_NULL: &'static str = concat!(env!("CARGO_PKG_VERSION"), "\0");
+    const VERSION_WITH_NULL: &str = concat!(env!("CARGO_PKG_VERSION"), "\0");
     VERSION_WITH_NULL.as_ptr() as *const c_char
 }

--- a/crates/ombrac-client/src/logging.rs
+++ b/crates/ombrac-client/src/logging.rs
@@ -1,165 +1,94 @@
 use std::ffi::c_char;
-use std::sync::{Mutex, Once};
+use std::io::Write;
+use std::sync::{Arc, OnceLock};
 
-use tracing::{Level, Metadata};
+use arc_swap::ArcSwap;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{EnvFilter, Layer};
-
-use ombrac_macros::warn;
+use tracing_subscriber::{EnvFilter, Registry};
 
 use crate::config::LoggingConfig;
 
 /// A type alias for the C-style callback function pointer.
-///
-/// The `level` parameter is an integer representation of the log level:
-/// - `0`: TRACE
-/// - `1`: DEBUG
-/// - `2`: INFO
-/// - `3`: WARN
-/// - `4`: ERROR
-pub type LogCallback = extern "C" fn(level: i32, message: *const c_char, target: *const c_char);
+pub type LogCallback = extern "C" fn(message: *const c_char);
 
-// A global, thread-safe handle to the registered log callback.
-static LOG_CALLBACK: Mutex<Option<LogCallback>> = Mutex::new(None);
-static LOGGING_INIT: Once = Once::new();
+// A global, thread-safe, and lock-free handle to the registered log callback.
+static LOG_CALLBACK: OnceLock<ArcSwap<Option<LogCallback>>> = OnceLock::new();
 
-pub enum LoggingMode {
-    Callback(LogCallback),
-    Default(LoggingConfig),
+/// Returns a reference to the global `ArcSwap<Option<LogCallback>>`.
+/// Initializes it on first access.
+fn get_log_callback_handle() -> &'static ArcSwap<Option<LogCallback>> {
+    LOG_CALLBACK.get_or_init(|| ArcSwap::from(Arc::new(None)))
 }
 
-pub fn init(mode: LoggingMode) {
-    LOGGING_INIT.call_once(|| {
-        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+/// A custom writer that forwards formatted log messages to the FFI callback.
+struct FfiWriter;
 
-        match mode {
-            LoggingMode::Callback(callback) => {
-                set_log_callback(Some(callback));
-                tracing_subscriber::registry()
-                    .with(filter)
-                    .with(FfiLayer)
-                    .init();
-            }
-            LoggingMode::Default(config) => {
-                let log_level = config
-                    .log_level
-                    .as_deref()
-                    .map(|level_str| {
-                        level_str.parse().unwrap_or_else(|_| {
-                            warn!("Invalid log level '{}', defaulting to WARN", level_str);
-                            tracing::Level::WARN
-                        })
-                    })
-                    .unwrap_or(tracing::Level::WARN);
-
-                let subscriber = tracing_subscriber::fmt()
-                    .with_thread_ids(true)
-                    .with_max_level(log_level);
-
-                let (non_blocking, guard) = if let Some(path) = &config.log_dir {
-                    let prefix = config
-                        .log_prefix
-                        .as_deref()
-                        .unwrap_or_else(|| std::path::Path::new("log"));
-                    let file_appender = tracing_appender::rolling::daily(path, prefix);
-                    tracing_appender::non_blocking(file_appender)
-                } else {
-                    tracing_appender::non_blocking(std::io::stdout())
-                };
-
-                // The guard must be held for the lifetime of the program to ensure logs are flushed.
-                // In a long-running application like this, we can "leak" it to achieve this.
-                std::mem::forget(guard);
-                subscriber.with_writer(non_blocking).init();
-            }
-        }
-    });
-}
-
-/// A simple `tracing_subscriber` layer that forwards log records to a C callback.
-pub struct FfiLayer;
-
-impl<S> Layer<S> for FfiLayer
-where
-    S: tracing::Subscriber,
-{
-    fn enabled(
-        &self,
-        _metadata: &Metadata<'_>,
-        _ctx: tracing_subscriber::layer::Context<'_, S>,
-    ) -> bool {
-        // We want to be enabled if a callback is set.
-        LOG_CALLBACK.lock().unwrap().is_some()
-    }
-
-    fn on_event(
-        &self,
-        event: &tracing::Event<'_>,
-        _ctx: tracing_subscriber::layer::Context<'_, S>,
-    ) {
-        // If a callback is registered, format the event and invoke the callback.
-        if let Some(callback) = *LOG_CALLBACK.lock().unwrap() {
-            let metadata = event.metadata();
-            let level = metadata.level();
-            let target = metadata.target();
-
-            // A simple visitor to extract the `message` field from the event.
-            struct MessageVisitor {
-                message: String,
-            }
-
-            impl tracing::field::Visit for MessageVisitor {
-                fn record_debug(
-                    &mut self,
-                    field: &tracing::field::Field,
-                    value: &dyn std::fmt::Debug,
-                ) {
-                    if field.name() == "message" {
-                        self.message = format!("{:?}", value);
-                    }
-                }
-            }
-
-            let mut visitor = MessageVisitor {
-                message: String::new(),
+impl Write for FfiWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let callback_handle = get_log_callback_handle();
+        let callback_arc = callback_handle.load();
+        if let Some(callback) = **callback_arc {
+            // Trim trailing newline, as the callback consumer might add its own.
+            let message_bytes = if buf.last() == Some(&b'\n') {
+                &buf[..buf.len() - 1]
+            } else {
+                buf
             };
-            event.record(&mut visitor);
 
-            // Convert the message and target to C-compatible strings.
-            if let Ok(message_cstr) = std::ffi::CString::new(visitor.message)
-                && let Ok(target_cstr) = std::ffi::CString::new(target)
-            {
-                // Invoke the callback.
-                callback(
-                    level_to_int(level),
-                    message_cstr.as_ptr(),
-                    target_cstr.as_ptr(),
-                );
+            if let Ok(message_cstr) = std::ffi::CString::new(message_bytes) {
+                callback(message_cstr.as_ptr());
             }
         }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }
 
-/// Sets the global log callback.
-/// This function should be called by the FFI consumer before starting the service.
+/// Initializes logging for a standalone binary application.
+///
+/// This setup directs logs to `stdout`.
+pub fn init_for_binary(config: &LoggingConfig) {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(config.log_level.as_deref().unwrap_or("info")));
+
+    let (non_blocking_writer, _guard) = tracing_appender::non_blocking(std::io::stdout());
+    std::mem::forget(_guard); // Keep the guard alive for the duration of the program.
+
+    let layer = tracing_subscriber::fmt::layer()
+        .with_writer(non_blocking_writer)
+        .with_thread_ids(true);
+
+    Registry::default().with(filter).with(layer).init();
+}
+
+/// Initializes logging for FFI consumers.
+///
+/// This setup directs logs to the registered FFI callback.
+pub fn init_for_ffi(config: &LoggingConfig) {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(config.log_level.as_deref().unwrap_or("info")));
+
+    let (ffi_writer, _guard) = tracing_appender::non_blocking(FfiWriter);
+    std::mem::forget(_guard); // Keep the guard alive.
+
+    let layer = tracing_subscriber::fmt::layer()
+        .with_writer(ffi_writer)
+        .with_ansi(false) // ANSI codes are not expected by FFI consumers.
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_level(true);
+
+    Registry::default().with(filter).with(layer).init();
+}
+
+/// Sets or clears the global log callback for FFI.
+///
+/// This function should be called before `init_for_ffi`.
 pub fn set_log_callback(callback: Option<LogCallback>) {
-    *LOG_CALLBACK.lock().unwrap() = callback;
-}
-
-/// Converts a `tracing::Level` to a simple integer representation for FFI.
-fn level_to_int(level: &Level) -> i32 {
-    if *level == Level::ERROR {
-        4
-    } else if *level == Level::WARN {
-        3
-    } else if *level == Level::INFO {
-        2
-    } else if *level == Level::DEBUG {
-        1
-    } else if *level == Level::TRACE {
-        0
-    } else {
-        -1 // Unknown
-    }
+    let callback_handle = get_log_callback_handle();
+    callback_handle.store(Arc::new(callback));
 }

--- a/crates/ombrac-client/src/service.rs
+++ b/crates/ombrac-client/src/service.rs
@@ -95,9 +95,6 @@ where
     where
         Builder: ServiceBuilder<Initiator = T, Connection = C>,
     {
-        #[cfg(feature = "tracing")]
-        crate::logging::init(crate::logging::LoggingMode::Default(config.logging.clone()));
-
         let mut handles = Vec::new();
         let client = Builder::build(&config).await?;
         let (shutdown_tx, _) = broadcast::channel(1);

--- a/crates/ombrac-server/Cargo.toml
+++ b/crates/ombrac-server/Cargo.toml
@@ -55,6 +55,7 @@ bytes = { workspace = true }
 blake3 = { workspace = true }
 bincode = { workspace = true }
 futures = { workspace = true }
+arc-swap = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 figment = { workspace = true, features = ["json"] }

--- a/crates/ombrac-server/bin/main.rs
+++ b/crates/ombrac-server/bin/main.rs
@@ -9,6 +9,10 @@ fn main() {
         }
     };
 
+    // Initialize logging for the binary.
+    #[cfg(feature = "tracing")]
+    ombrac_server::logging::init_for_binary(&config.logging);
+
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()

--- a/crates/ombrac-server/ombrac_server.h
+++ b/crates/ombrac-server/ombrac_server.h
@@ -7,15 +7,8 @@
 
 /**
  * A type alias for the C-style callback function pointer.
- *
- * The `level` parameter is an integer representation of the log level:
- * - `0`: TRACE
- * - `1`: DEBUG
- * - `2`: INFO
- * - `3`: WARN
- * - `4`: ERROR
  */
-typedef void (*LogCallback)(int32_t level, const char *message, const char *target);
+typedef void (*LogCallback)(const char *message);
 
 /**
  * Initializes the logging system to use a C-style callback for log messages.

--- a/crates/ombrac-server/src/config.rs
+++ b/crates/ombrac-server/src/config.rs
@@ -137,16 +137,6 @@ pub struct LoggingConfig {
     #[clap(long, help_heading = "Logging", value_name = "LEVEL")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log_level: Option<String>,
-
-    /// Path to the log directory
-    #[clap(long, value_name = "PATH", help_heading = "Logging")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub log_dir: Option<PathBuf>,
-
-    /// Prefix for log file names (only used when log dir is specified)
-    #[clap(long, value_name = "STR", help_heading = "Logging")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub log_prefix: Option<PathBuf>,
 }
 
 #[cfg(feature = "transport-quic")]
@@ -194,8 +184,6 @@ impl Default for LoggingConfig {
     fn default() -> Self {
         Self {
             log_level: Some("INFO".to_string()),
-            log_dir: None,
-            log_prefix: None,
         }
     }
 }

--- a/crates/ombrac-server/src/logging.rs
+++ b/crates/ombrac-server/src/logging.rs
@@ -1,155 +1,94 @@
 use std::ffi::c_char;
-use std::sync::{Mutex, Once};
+use std::io::Write;
+use std::sync::{Arc, OnceLock};
 
-use tracing::{Level, Metadata};
+use arc_swap::ArcSwap;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{EnvFilter, Layer};
-
-use ombrac_macros::warn;
+use tracing_subscriber::{EnvFilter, Registry};
 
 use crate::config::LoggingConfig;
 
 /// A type alias for the C-style callback function pointer.
-///
-/// The `level` parameter is an integer representation of the log level:
-/// - `0`: TRACE
-/// - `1`: DEBUG
-/// - `2`: INFO
-/// - `3`: WARN
-/// - `4`: ERROR
-pub type LogCallback = extern "C" fn(level: i32, message: *const c_char, target: *const c_char);
+pub type LogCallback = extern "C" fn(message: *const c_char);
 
-// A global, thread-safe handle to the registered log callback.
-static LOG_CALLBACK: Mutex<Option<LogCallback>> = Mutex::new(None);
-static LOGGING_INIT: Once = Once::new();
+// A global, thread-safe, and lock-free handle to the registered log callback.
+static LOG_CALLBACK: OnceLock<ArcSwap<Option<LogCallback>>> = OnceLock::new();
 
-pub enum LoggingMode {
-    Callback(LogCallback),
-    Default(LoggingConfig),
+/// Returns a reference to the global `ArcSwap<Option<LogCallback>>`.
+/// Initializes it on first access.
+fn get_log_callback_handle() -> &'static ArcSwap<Option<LogCallback>> {
+    LOG_CALLBACK.get_or_init(|| ArcSwap::from(Arc::new(None)))
 }
 
-pub fn init(mode: LoggingMode) {
-    LOGGING_INIT.call_once(|| {
-        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+/// A custom writer that forwards formatted log messages to the FFI callback.
+struct FfiWriter;
 
-        match mode {
-            LoggingMode::Callback(callback) => {
-                set_log_callback(Some(callback));
-                tracing_subscriber::registry()
-                    .with(filter)
-                    .with(FfiLayer)
-                    .init();
-            }
-            LoggingMode::Default(config) => {
-                let log_level = config
-                    .log_level
-                    .as_deref()
-                    .map(|level_str| {
-                        level_str.parse().unwrap_or_else(|_| {
-                            warn!("Invalid log level '{}', defaulting to WARN", level_str);
-                            tracing::Level::WARN
-                        })
-                    })
-                    .unwrap_or(tracing::Level::WARN);
-
-                let subscriber = tracing_subscriber::fmt()
-                    .with_thread_ids(true)
-                    .with_max_level(log_level);
-
-                let (non_blocking, guard) = if let Some(path) = &config.log_dir {
-                    let prefix = config
-                        .log_prefix
-                        .as_deref()
-                        .unwrap_or_else(|| std::path::Path::new("log"));
-                    let file_appender = tracing_appender::rolling::daily(path, prefix);
-                    tracing_appender::non_blocking(file_appender)
-                } else {
-                    tracing_appender::non_blocking(std::io::stdout())
-                };
-
-                std::mem::forget(guard);
-                subscriber.with_writer(non_blocking).init();
-            }
-        }
-    });
-}
-
-/// A simple `tracing_subscriber` layer that forwards log records to a C callback.
-pub struct FfiLayer;
-
-impl<S> Layer<S> for FfiLayer
-where
-    S: tracing::Subscriber,
-{
-    fn enabled(
-        &self,
-        _metadata: &Metadata<'_>,
-        _ctx: tracing_subscriber::layer::Context<'_, S>,
-    ) -> bool {
-        LOG_CALLBACK.lock().unwrap().is_some()
-    }
-
-    fn on_event(
-        &self,
-        event: &tracing::Event<'_>,
-        _ctx: tracing_subscriber::layer::Context<'_, S>,
-    ) {
-        if let Some(callback) = *LOG_CALLBACK.lock().unwrap() {
-            let metadata = event.metadata();
-            let level = metadata.level();
-            let target = metadata.target();
-
-            struct MessageVisitor {
-                message: String,
-            }
-
-            impl tracing::field::Visit for MessageVisitor {
-                fn record_debug(
-                    &mut self,
-                    field: &tracing::field::Field,
-                    value: &dyn std::fmt::Debug,
-                ) {
-                    if field.name() == "message" {
-                        self.message = format!("{:?}", value);
-                    }
-                }
-            }
-
-            let mut visitor = MessageVisitor {
-                message: String::new(),
+impl Write for FfiWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let callback_handle = get_log_callback_handle();
+        let callback_arc = callback_handle.load();
+        if let Some(callback) = **callback_arc {
+            // Trim trailing newline, as the callback consumer might add its own.
+            let message_bytes = if buf.last() == Some(&b'\n') {
+                &buf[..buf.len() - 1]
+            } else {
+                buf
             };
-            event.record(&mut visitor);
 
-            if let Ok(message_cstr) = std::ffi::CString::new(visitor.message)
-                && let Ok(target_cstr) = std::ffi::CString::new(target)
-            {
-                callback(
-                    level_to_int(level),
-                    message_cstr.as_ptr(),
-                    target_cstr.as_ptr(),
-                );
+            if let Ok(message_cstr) = std::ffi::CString::new(message_bytes) {
+                callback(message_cstr.as_ptr());
             }
         }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }
 
+/// Initializes logging for a standalone binary application.
+///
+/// This setup directs logs to `stdout`.
+pub fn init_for_binary(config: &LoggingConfig) {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(config.log_level.as_deref().unwrap_or("info")));
+
+    let (non_blocking_writer, _guard) = tracing_appender::non_blocking(std::io::stdout());
+    std::mem::forget(_guard); // Keep the guard alive for the duration of the program.
+
+    let layer = tracing_subscriber::fmt::layer()
+        .with_writer(non_blocking_writer)
+        .with_thread_ids(true);
+
+    Registry::default().with(filter).with(layer).init();
+}
+
+/// Initializes logging for FFI consumers.
+///
+/// This setup directs logs to the registered FFI callback.
+pub fn init_for_ffi(config: &LoggingConfig) {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(config.log_level.as_deref().unwrap_or("info")));
+
+    let (ffi_writer, _guard) = tracing_appender::non_blocking(FfiWriter);
+    std::mem::forget(_guard); // Keep the guard alive.
+
+    let layer = tracing_subscriber::fmt::layer()
+        .with_writer(ffi_writer)
+        .with_ansi(false) // ANSI codes are not expected by FFI consumers.
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_level(true);
+
+    Registry::default().with(filter).with(layer).init();
+}
+
+/// Sets or clears the global log callback for FFI.
+///
+/// This function should be called before `init_for_ffi`.
 pub fn set_log_callback(callback: Option<LogCallback>) {
-    *LOG_CALLBACK.lock().unwrap() = callback;
-}
-
-fn level_to_int(level: &Level) -> i32 {
-    if *level == Level::ERROR {
-        4
-    } else if *level == Level::WARN {
-        3
-    } else if *level == Level::INFO {
-        2
-    } else if *level == Level::DEBUG {
-        1
-    } else if *level == Level::TRACE {
-        0
-    } else {
-        -1 // Unknown
-    }
+    let callback_handle = get_log_callback_handle();
+    callback_handle.store(Arc::new(callback));
 }

--- a/crates/ombrac-server/src/service.rs
+++ b/crates/ombrac-server/src/service.rs
@@ -92,9 +92,6 @@ where
     where
         Builder: ServiceBuilder<Acceptor = T, Connection = C>,
     {
-        #[cfg(feature = "tracing")]
-        crate::logging::init(crate::logging::LoggingMode::Default(config.logging.clone()));
-
         let server = Builder::build(&config).await?;
         let (shutdown_tx, shutdown_rx) = broadcast::channel(1);
 


### PR DESCRIPTION
The FFI logging mechanism in `ombrac-client` has been significantly refactored to simplify its interface and improve flexibility.

Changes include:
- The `LogCallback` signature was simplified to accept only a pre-formatted message string, moving log formatting responsibility to the Rust side.
- Introduced `init_for_binary` and `init_for_ffi` functions to provide distinct logging setups for the client binary and FFI consumers.
- Implemented `FfiWriter` to integrate the FFI callback with `tracing-subscriber`, ensuring consistent log formatting.
- Renamed the FFI function `ombrac_client_logging_init` to `ombrac_client_set_log_callback` for clarity.
- Consolidated `arc-swap` dependency usage and removed `serde_bytes` from the workspace.