### PR TITLE
refactor(datagram): simplify UDP session handling and remove fragmentation

### DIFF
--- a/crates/ombrac-client/src/client.rs
+++ b/crates/ombrac-client/src/client.rs
@@ -87,15 +87,9 @@ where
     /// for sending and receiving UDP datagrams over the existing connection.
     #[cfg(feature = "datagram")]
     pub fn open_associate(&self) -> UdpSession<T, C> {
-        use ombrac_macros::info;
-
         let session_id = self
             .session_id_counter
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        info!(
-            "[Client] New UDP session created with session_id={}",
-            session_id
-        );
         let receiver = self.udp_dispatcher.register_session(session_id);
 
         UdpSession::new(

--- a/crates/ombrac-client/src/endpoint/tun.rs
+++ b/crates/ombrac-client/src/endpoint/tun.rs
@@ -41,7 +41,7 @@ mod fakedns {
     use ombrac_macros::{debug, warn};
 
     const DNS_RESPONSE_TTL: u32 = 5;
-    const CACHE_TTL: Duration = Duration::from_secs(DNS_RESPONSE_TTL as u64 + (7 * 24 * 60 * 60));
+    const CACHE_TTL: Duration = Duration::from_secs(DNS_RESPONSE_TTL as u64 + (60 * 60));
 
     #[derive(Clone)]
     pub struct FakeDns {


### PR DESCRIPTION
- Removed the fragment ID counter and associated logic from the UdpDispatcher and DatagramTunnel, streamlining the process of sending UDP datagrams.
- Updated the send_datagram function to send packets as unfragmented, allowing the application layer to manage MTU discovery and packet sizing.
- Adjusted related documentation to reflect the changes in datagram handling.
- Modified the CACHE_TTL constant in the FakeDns module for improved DNS response caching.