### PR TITLE
fix(tun): improve socket management and IO handling

### DIFF
--- a/crates/ombrac-client/src/connection/datagram.rs
+++ b/crates/ombrac-client/src/connection/datagram.rs
@@ -9,7 +9,7 @@ use tokio_util::sync::CancellationToken;
 
 use ombrac::protocol::{Address, UdpPacket};
 use ombrac::reassembly::UdpReassembler;
-use ombrac_macros::{debug, warn};
+use ombrac_macros::warn;
 use ombrac_transport::{Connection, Initiator};
 
 use super::ClientConnection;
@@ -223,13 +223,7 @@ where
 
     /// Sends a UDP datagram to the specified destination through the tunnel.
     pub async fn send_to(&self, data: Bytes, dest_addr: Address) -> io::Result<()> {
-        send_datagram(
-            &self.connection,
-            self.session_id,
-            dest_addr,
-            data,
-        )
-        .await
+        send_datagram(&self.connection, self.session_id, dest_addr, data).await
     }
 
     /// Receives a UDP datagram from the tunnel for this session.

--- a/crates/ombrac-server/src/connection/datagram.rs
+++ b/crates/ombrac-server/src/connection/datagram.rs
@@ -302,11 +302,7 @@ impl<C: Connection> DownstreamHandler<C> {
     /// The packet is sent as-is, allowing the application layer (e.g., QUIC)
     /// to handle MTU discovery and packet sizing. This ensures proper PMTUD
     /// behavior and optimal performance.
-    async fn process_and_send_datagram(
-        &self,
-        address: Address,
-        data: Bytes,
-    ) -> io::Result<()> {
+    async fn process_and_send_datagram(&self, address: Address, data: Bytes) -> io::Result<()> {
         let packet = UdpPacket::Unfragmented {
             session_id: self.session_id,
             address,


### PR DESCRIPTION
- Added logic to skip sockets marked as dropped during IO processing to prevent unnecessary operations.
- Updated comments for clarity regarding socket pruning after IO.
- Enhanced conditions for notifying workers and handling socket states to ensure proper functionality.