### PR TITLE
fix(server): don't terminate stream accept loop on single stream error

### DIFF
--- a/crates/ombrac-server/src/connection/stream.rs
+++ b/crates/ombrac-server/src/connection/stream.rs
@@ -13,7 +13,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
 use ombrac::{codec, protocol};
-use ombrac_macros::info;
+use ombrac_macros::{info, warn};
 use ombrac_transport::Connection;
 use ombrac_transport::io::{CopyBidirectionalStats, copy_bidirectional};
 
@@ -44,7 +44,13 @@ impl<C: Connection> StreamTunnel<C> {
                 biased;
                 _ = self.shutdown.cancelled() => break,
                 result = self.connection.accept_bidirectional() => {
-                    let stream = result?;
+                    let stream = match result {
+                        Ok(s) => s,
+                        Err(e) => {
+                            warn!("failed to accept stream: {}", e);
+                            continue;
+                        }
+                    };
                     let semaphore = Arc::clone(&self.semaphore);
                     let shutdown = self.shutdown.child_token();
 


### PR DESCRIPTION
A transient stream accept failure (e.g. client reset before the stream was fully opened) propagated via ? and killed the entire accept loop for that QUIC connection, making all subsequent requests on that connection silently fail. Log the error and continue instead.