### PR TITLE
fix(protocol): cap fragment_count to prevent memory exhaustion DoS

### DIFF
--- a/crates/ombrac/src/reassembly.rs
+++ b/crates/ombrac/src/reassembly.rs
@@ -14,6 +14,10 @@ const DEFAULT_REASSEMBLY_TIMEOUT: Duration = Duration::from_secs(10);
 /// Default maximum number of concurrent reassembly operations [8192]
 const DEFAULT_MAX_CONCURRENT_REASSEMBLIES: u64 = 8192;
 
+/// Maximum allowed number of fragments per packet to prevent memory exhaustion.
+/// A 64KB UDP packet with 256-byte fragments = 256 fragments max.
+const MAX_FRAGMENT_COUNT: u16 = 256;
+
 /// Cache key type: (session_id, fragment_id)
 ///
 /// The combination ensures fragments from different sessions don't collide,
@@ -70,8 +74,8 @@ impl ReassemblyBuffer {
         };
 
         // Validate fragment_count
-        if fragment_count == 0 {
-            return false; // Invalid fragment
+        if fragment_count == 0 || fragment_count > MAX_FRAGMENT_COUNT {
+            return false; // Invalid or oversized fragment count
         }
 
         // Initialize the buffer with the fragment_count from the first fragment we see.


### PR DESCRIPTION
An attacker could send a fragment with fragment_count=65535 and never deliver the remaining pieces, causing the server to allocate ~1 MB per (session_id, fragment_id) pair. With DEFAULT_MAX_CONCURRENT_REASSEMBLIES at 8192 that reaches ~8 GB.

Introduce MAX_FRAGMENT_COUNT = 256 and reject fragments that exceed it. A 64 KB UDP payload split into 256-byte chunks needs at most 256 fragments, so this limit does not affect legitimate traffic.