### PR TITLE
fix(server): propagate DNS resolver init error instead of panicking

### DIFF
--- a/crates/ombrac-server/src/connection/dns.rs
+++ b/crates/ombrac-server/src/connection/dns.rs
@@ -10,12 +10,16 @@ static DNS_RESOLVER: OnceCell<TokioResolver> = OnceCell::const_new();
 /// Gets or initializes the global DNS resolver instance.
 ///
 /// The resolver is created from system configuration on first use.
-pub(crate) async fn get_dns_resolver() -> &'static TokioResolver {
+///
+/// # Errors
+///
+/// Returns an error if the system DNS configuration cannot be read.
+pub(crate) async fn get_dns_resolver() -> io::Result<&'static TokioResolver> {
     DNS_RESOLVER
-        .get_or_init(|| async {
+        .get_or_try_init(|| async {
             TokioResolver::builder_tokio()
-                .expect("failed to create dns resolver from system config")
-                .build()
+                .map(|b| b.build())
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("failed to create dns resolver from system config: {e}")))
         })
         .await
 }
@@ -42,7 +46,7 @@ pub(crate) async fn resolve_domain(domain: &[u8], port: u16) -> io::Result<Socke
     })?;
 
     // Use hickory-resolver for DNS resolution
-    let resolver = get_dns_resolver().await;
+    let resolver = get_dns_resolver().await?;
     let lookup_result = resolver.lookup_ip(domain_str).await.map_err(|e| {
         io::Error::new(
             io::ErrorKind::NotFound,


### PR DESCRIPTION
get_dns_resolver previously called .expect() inside OnceCell::get_or_init, which panics at runtime when the system has no DNS configuration. Change to OnceCell::get_or_try_init so the error is returned as io::Result and propagated to callers instead of unwinding the thread.