### PR TITLE
fix(transport): use bounded channel and stop accept loop on receiver closed

### DIFF
--- a/crates/ombrac-transport/src/quic/server.rs
+++ b/crates/ombrac-transport/src/quic/server.rs
@@ -128,7 +128,7 @@ impl Server {
             runtime,
         )?);
 
-        let (sender, receiver) = async_channel::unbounded();
+        let (sender, receiver) = async_channel::bounded(128);
         let (shutdown_sender, shutdown_receiver) = watch::channel(());
 
         tokio::spawn(accept_loop(endpoint.clone(), sender, shutdown_receiver));
@@ -157,7 +157,8 @@ async fn accept_loop(
                         Ok(connection) => {
                             debug!("Accept connection from {}", connection.remote_address());
                             if sender_clone.send(connection).await.is_err() {
-                                warn!("Connection receiver is closed");
+                                warn!("Connection receiver is closed, stopping accept loop");
+                                return;
                             }
                         }
                         Err(_err) => {


### PR DESCRIPTION
The QUIC accept_loop used an unbounded channel, allowing accepted connections to accumulate without limit if the consumer was slow (e.g. during auth). Switch to bounded(128) to apply back-pressure.

Also stop spawning new connection tasks when send() fails because the receiver is gone — previously these connections were accepted and then silently leaked with no way to ever be consumed.