### PR TITLE
fix(netstack): use graceful FIN instead of RST on TCP shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,11 +252,13 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benches"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
+ "bytes",
  "criterion",
  "ombrac",
- "tests-support",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -589,6 +591,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -1788,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "ombrac"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "bincode",
  "bytes",
@@ -1800,7 +1803,7 @@ dependencies = [
 
 [[package]]
 name = "ombrac-client"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -1836,14 +1839,14 @@ dependencies = [
 
 [[package]]
 name = "ombrac-macros"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "ombrac-netstack"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "bytes",
  "crossbeam-queue",
@@ -1858,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "ombrac-server"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -1885,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "ombrac-transport"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -2725,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "blake3",
  "bytes",
@@ -2742,7 +2745,7 @@ dependencies = [
 
 [[package]]
 name = "tests-support"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "bytes",
  "ombrac-transport",

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,11 +11,23 @@ keywords.workspace = true
 readme = "../../README.md"
 
 [dependencies]
-tests-support = { path = "../tests/support" }
-
 ombrac = { workspace = true }
-criterion = { workspace = true, features = ["default"] }
+criterion = { workspace = true, features = ["default", "async_tokio"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio-util = { workspace = true, features = ["codec"] }
+bytes = { workspace = true, features = ["std"] }
 
+[[bench]]
+name = "throughput"
+harness = false
+
+[[bench]]
+name = "latency"
+harness = false
+
+[[bench]]
+name = "concurrency"
+harness = false
 
 [lints]
 workspace = true

--- a/benches/benches/concurrency.rs
+++ b/benches/benches/concurrency.rs
@@ -1,0 +1,152 @@
+use bytes::Bytes;
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use ombrac::protocol::{Address, UdpPacket};
+use ombrac::reassembly::UdpReassembler;
+use std::net::{Ipv4Addr, SocketAddrV4};
+use std::sync::Arc;
+
+// ── Concurrent reassembly sessions ───────────────────────────────────────────
+
+fn bench_concurrent_sessions(c: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let addr = Address::SocketV4(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 9000));
+    let data_size = 8192usize;
+    let chunk = 1200usize;
+    let session_counts: &[usize] = &[1, 8, 64, 256];
+
+    let mut group = c.benchmark_group("concurrency/reassembly_sessions");
+    for &sessions in session_counts {
+        let total_bytes = (data_size * sessions) as u64;
+        group.throughput(Throughput::Bytes(total_bytes));
+
+        group.bench_with_input(
+            BenchmarkId::new("sessions", sessions),
+            &sessions,
+            |b, &n| {
+                b.to_async(&runtime).iter(|| {
+                    let addr = addr.clone();
+                    async move {
+                        let reassembler = Arc::new(UdpReassembler::default());
+                        let mut handles = Vec::with_capacity(n);
+
+                        for session_id in 0..n as u64 {
+                            let r = reassembler.clone();
+                            let a = addr.clone();
+                            let data = Bytes::from(vec![(session_id % 256) as u8; data_size]);
+                            let fragments: Vec<UdpPacket> =
+                                UdpPacket::split_packet(session_id, a, data, chunk, 0).collect();
+
+                            handles.push(tokio::spawn(async move {
+                                let mut result = None;
+                                for f in fragments {
+                                    result = r.process(f).await.unwrap();
+                                }
+                                assert!(result.is_some());
+                            }));
+                        }
+
+                        for h in handles {
+                            h.await.unwrap();
+                        }
+                    }
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+// ── Concurrent encode/decode ──────────────────────────────────────────────────
+
+fn bench_concurrent_encode(c: &mut Criterion) {
+    use ombrac::protocol::{ClientConnect, encode};
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let msg = ClientConnect {
+        address: Address::SocketV4(SocketAddrV4::new(Ipv4Addr::new(1, 2, 3, 4), 443)),
+    };
+    let worker_counts: &[usize] = &[1, 4, 16, 64];
+
+    let mut group = c.benchmark_group("concurrency/encode");
+    for &workers in worker_counts {
+        group.bench_with_input(
+            BenchmarkId::new("workers", workers),
+            &workers,
+            |b, &n| {
+                b.to_async(&runtime).iter(|| {
+                    let msg = msg.clone();
+                    async move {
+                        let mut handles = Vec::with_capacity(n);
+                        for _ in 0..n {
+                            let m = msg.clone();
+                            handles.push(tokio::spawn(async move {
+                                for _ in 0..100 {
+                                    encode(&m).unwrap();
+                                }
+                            }));
+                        }
+                        for h in handles {
+                            h.await.unwrap();
+                        }
+                    }
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+// ── Reassembly with duplicate fragments ──────────────────────────────────────
+
+fn bench_reassembly_with_duplicates(c: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let addr = Address::SocketV4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 9002));
+    let data = Bytes::from(vec![3u8; 4800]);
+    let chunk = 1200usize;
+    // 4 fragments, each duplicated once
+    let mut fragments: Vec<UdpPacket> =
+        UdpPacket::split_packet(10, addr.clone(), data, chunk, 1).collect();
+    let dups = fragments.clone();
+    fragments.extend(dups);
+
+    let mut group = c.benchmark_group("concurrency/reassembly_duplicates");
+    group.throughput(Throughput::Elements(fragments.len() as u64));
+    group.bench_function("4_frags_2x_duplication", |b| {
+        b.to_async(&runtime).iter(|| {
+            let frags = fragments.clone();
+            async move {
+                let r = UdpReassembler::default();
+                let mut result = None;
+                for f in frags {
+                    if let Some(r) = r.process(f).await.unwrap() {
+                        result = Some(r);
+                    }
+                }
+                assert!(result.is_some());
+            }
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_concurrent_sessions,
+    bench_concurrent_encode,
+    bench_reassembly_with_duplicates,
+);
+criterion_main!(benches);

--- a/benches/benches/latency.rs
+++ b/benches/benches/latency.rs
@@ -1,0 +1,138 @@
+use bytes::Bytes;
+use criterion::{Criterion, criterion_group, criterion_main};
+use ombrac::codec::length_codec;
+use ombrac::protocol::{
+    Address, ClientConnect, ClientHello, ServerConnectResponse, UdpPacket, decode, encode,
+};
+use std::net::{Ipv4Addr, SocketAddrV4};
+use tokio_util::codec::{Decoder, Encoder};
+
+// ── Per-operation latency ─────────────────────────────────────────────────────
+
+fn bench_encode_latency(c: &mut Criterion) {
+    let mut group = c.benchmark_group("latency/encode");
+
+    let hello = ClientHello {
+        version: 1,
+        secret: [0u8; 32],
+        options: Bytes::new(),
+    };
+    let connect = ClientConnect {
+        address: Address::SocketV4(SocketAddrV4::new(Ipv4Addr::new(93, 184, 216, 34), 80)),
+    };
+    let response_ok = ServerConnectResponse::Ok;
+    let response_err = ServerConnectResponse::Err {
+        kind: ombrac::protocol::ConnectErrorKind::ConnectionRefused,
+        message: "connection refused".to_string(),
+    };
+
+    group.bench_function("ClientHello", |b| b.iter(|| encode(&hello).unwrap()));
+    group.bench_function("ClientConnect/ipv4", |b| b.iter(|| encode(&connect).unwrap()));
+    group.bench_function("ServerConnectResponse/Ok", |b| {
+        b.iter(|| encode(&response_ok).unwrap())
+    });
+    group.bench_function("ServerConnectResponse/Err", |b| {
+        b.iter(|| encode(&response_err).unwrap())
+    });
+    group.finish();
+}
+
+fn bench_decode_latency(c: &mut Criterion) {
+    let mut group = c.benchmark_group("latency/decode");
+
+    let hello = ClientHello {
+        version: 1,
+        secret: [0u8; 32],
+        options: Bytes::new(),
+    };
+    let connect = ClientConnect {
+        address: Address::SocketV4(SocketAddrV4::new(Ipv4Addr::new(93, 184, 216, 34), 80)),
+    };
+
+    let encoded_hello = encode(&hello).unwrap();
+    let encoded_connect = encode(&connect).unwrap();
+
+    group.bench_function("ClientHello", |b| {
+        b.iter(|| decode::<ClientHello>(&encoded_hello).unwrap())
+    });
+    group.bench_function("ClientConnect/ipv4", |b| {
+        b.iter(|| decode::<ClientConnect>(&encoded_connect).unwrap())
+    });
+    group.finish();
+}
+
+fn bench_roundtrip_latency(c: &mut Criterion) {
+    let mut group = c.benchmark_group("latency/roundtrip");
+
+    let connect = ClientConnect {
+        address: Address::Domain(Bytes::copy_from_slice(b"example.com"), 443),
+    };
+    let udp = UdpPacket::Unfragmented {
+        session_id: 42,
+        address: Address::SocketV4(SocketAddrV4::new(Ipv4Addr::new(8, 8, 8, 8), 53)),
+        data: Bytes::from(vec![0u8; 512]),
+    };
+
+    group.bench_function("ClientConnect/domain", |b| {
+        b.iter(|| {
+            let enc = encode(&connect).unwrap();
+            decode::<ClientConnect>(&enc).unwrap()
+        })
+    });
+    group.bench_function("UdpPacket/unfragmented_512", |b| {
+        b.iter(|| {
+            let enc = encode(&udp).unwrap();
+            decode::<UdpPacket>(&enc).unwrap()
+        })
+    });
+    group.finish();
+}
+
+// ── Codec framing latency ─────────────────────────────────────────────────────
+
+fn bench_codec_frame_latency(c: &mut Criterion) {
+    use bytes::BytesMut;
+
+    let mut group = c.benchmark_group("latency/codec_frame");
+
+    let sizes: &[usize] = &[32, 256, 1400, 8192];
+    for &size in sizes {
+        let payload = Bytes::from(vec![0u8; size]);
+        group.bench_function(format!("encode_decode_{size}"), |b| {
+            b.iter(|| {
+                let mut codec = length_codec();
+                let mut buf = BytesMut::new();
+                Encoder::<Bytes>::encode(&mut codec, payload.clone(), &mut buf).unwrap();
+                codec.decode(&mut buf).unwrap().unwrap()
+            })
+        });
+    }
+    group.finish();
+}
+
+// ── Address parsing latency ───────────────────────────────────────────────────
+
+fn bench_address_parse(c: &mut Criterion) {
+    let mut group = c.benchmark_group("latency/address_parse");
+
+    group.bench_function("ipv4", |b| {
+        b.iter(|| Address::try_from("93.184.216.34:80").unwrap())
+    });
+    group.bench_function("ipv6", |b| {
+        b.iter(|| Address::try_from("[::1]:443").unwrap())
+    });
+    group.bench_function("domain", |b| {
+        b.iter(|| Address::try_from("example.com:8080").unwrap())
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_encode_latency,
+    bench_decode_latency,
+    bench_roundtrip_latency,
+    bench_codec_frame_latency,
+    bench_address_parse,
+);
+criterion_main!(benches);

--- a/benches/benches/throughput.rs
+++ b/benches/benches/throughput.rs
@@ -1,0 +1,159 @@
+use bytes::Bytes;
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use ombrac::protocol::{Address, ClientConnect, ClientHello, UdpPacket, decode, encode};
+use std::net::{Ipv4Addr, SocketAddrV4};
+
+// ── Serialization throughput ─────────────────────────────────────────────────
+
+fn bench_encode_client_hello(c: &mut Criterion) {
+    let msg = ClientHello {
+        version: 1,
+        secret: [0xab; 32],
+        options: Bytes::new(),
+    };
+
+    c.bench_function("encode/ClientHello", |b| {
+        b.iter(|| encode(&msg).unwrap());
+    });
+}
+
+fn bench_encode_client_connect(c: &mut Criterion) {
+    let mut group = c.benchmark_group("encode/ClientConnect");
+
+    let ipv4 = ClientConnect {
+        address: Address::SocketV4(SocketAddrV4::new(Ipv4Addr::new(1, 2, 3, 4), 443)),
+    };
+    let domain = ClientConnect {
+        address: Address::Domain(Bytes::copy_from_slice(b"example.com"), 443),
+    };
+
+    group.bench_function("ipv4", |b| b.iter(|| encode(&ipv4).unwrap()));
+    group.bench_function("domain", |b| b.iter(|| encode(&domain).unwrap()));
+    group.finish();
+}
+
+fn bench_encode_decode_udp_unfragmented(c: &mut Criterion) {
+    let sizes: &[usize] = &[64, 512, 1400, 8192, 65535];
+    let addr = Address::SocketV4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 53));
+
+    let mut group = c.benchmark_group("udp/unfragmented");
+    for &size in sizes {
+        let payload = Bytes::from(vec![0u8; size]);
+        let pkt = UdpPacket::Unfragmented {
+            session_id: 1,
+            address: addr.clone(),
+            data: payload.clone(),
+        };
+        let encoded = encode(&pkt).unwrap();
+
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::new("encode", size), &pkt, |b, p| {
+            b.iter(|| encode(p).unwrap());
+        });
+        group.bench_with_input(BenchmarkId::new("decode", size), &encoded, |b, e| {
+            b.iter(|| decode::<UdpPacket>(e).unwrap());
+        });
+    }
+    group.finish();
+}
+
+fn bench_udp_split_packet(c: &mut Criterion) {
+    let addr = Address::SocketV4(SocketAddrV4::new(Ipv4Addr::new(1, 1, 1, 1), 8080));
+    let sizes: &[usize] = &[1500, 16384, 65535];
+    let fragment_payload = 1200usize;
+
+    let mut group = c.benchmark_group("udp/split_packet");
+    for &size in sizes {
+        let data = Bytes::from(vec![0u8; size]);
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, d| {
+            b.iter(|| {
+                UdpPacket::split_packet(1, addr.clone(), d.clone(), fragment_payload, 0)
+                    .for_each(|_| {});
+            });
+        });
+    }
+    group.finish();
+}
+
+// ── UDP reassembly throughput ─────────────────────────────────────────────────
+
+fn bench_reassembly_in_order(c: &mut Criterion) {
+    use ombrac::reassembly::UdpReassembler;
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let addr = Address::SocketV4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 9000));
+    let sizes: &[usize] = &[1024, 16384, 65535];
+    let chunk = 1200usize;
+
+    let mut group = c.benchmark_group("reassembly/in_order");
+    for &total in sizes {
+        let data = Bytes::from(vec![1u8; total]);
+        let fragments: Vec<UdpPacket> = UdpPacket::split_packet(1, addr.clone(), data, chunk, 0)
+            .collect();
+
+        group.throughput(Throughput::Bytes(total as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(total),
+            &fragments,
+            |b, frags| {
+                b.to_async(&runtime).iter(|| async {
+                    let r = UdpReassembler::default();
+                    let mut result = None;
+                    for f in frags {
+                        result = r.process(f.clone()).await.unwrap();
+                    }
+                    assert!(result.is_some());
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_reassembly_out_of_order(c: &mut Criterion) {
+    use ombrac::reassembly::UdpReassembler;
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let addr = Address::SocketV4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 9001));
+    let total = 16384usize;
+    let chunk = 1200usize;
+    let data = Bytes::from(vec![2u8; total]);
+    let mut fragments: Vec<UdpPacket> =
+        UdpPacket::split_packet(2, addr.clone(), data, chunk, 0).collect();
+    // reverse order
+    fragments.reverse();
+
+    let mut group = c.benchmark_group("reassembly/out_of_order");
+    group.throughput(Throughput::Bytes(total as u64));
+    group.bench_function("16384_reversed", |b| {
+        b.to_async(&runtime).iter(|| async {
+            let r = UdpReassembler::default();
+            let mut result = None;
+            for f in &fragments {
+                result = r.process(f.clone()).await.unwrap();
+            }
+            assert!(result.is_some());
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_encode_client_hello,
+    bench_encode_client_connect,
+    bench_encode_decode_udp_unfragmented,
+    bench_udp_split_packet,
+    bench_reassembly_in_order,
+    bench_reassembly_out_of_order,
+);
+criterion_main!(benches);

--- a/crates/ombrac-netstack/src/tcp.rs
+++ b/crates/ombrac-netstack/src/tcp.rs
@@ -472,6 +472,15 @@ impl TcpConnectionWorker {
                 return false;
             }
 
+            if socket_control
+                .shared_state
+                .write_closed
+                .load(Ordering::Acquire)
+                && socket_control.send_buffer_cons.is_empty()
+            {
+                socket.close();
+            }
+
             if !socket.is_active() {
                 sockets.remove(*handle);
                 return false;
@@ -513,6 +522,7 @@ mod stream {
         pub(crate) recv_waker: AtomicWaker,
         pub(crate) send_waker: AtomicWaker,
         pub(crate) read_closed: AtomicBool,
+        pub(crate) write_closed: AtomicBool,
         pub(crate) socket_dropped: AtomicBool,
     }
 
@@ -522,6 +532,7 @@ mod stream {
                 recv_waker: AtomicWaker::new(),
                 send_waker: AtomicWaker::new(),
                 read_closed: AtomicBool::new(false),
+                write_closed: AtomicBool::new(false),
                 socket_dropped: AtomicBool::new(false),
             }
         }
@@ -587,7 +598,9 @@ mod stream {
             cx: &mut Context<'_>,
             buf: &[u8],
         ) -> Poll<std::io::Result<usize>> {
-            if self.shared_state.socket_dropped.load(Ordering::Acquire) {
+            if self.shared_state.socket_dropped.load(Ordering::Acquire)
+                || self.shared_state.write_closed.load(Ordering::Acquire)
+            {
                 return Poll::Ready(Err(std::io::Error::new(
                     std::io::ErrorKind::BrokenPipe,
                     "Socket is closing",
@@ -629,7 +642,7 @@ mod stream {
             std::task::ready!(self.as_mut().poll_flush(cx))?;
 
             self.shared_state
-                .socket_dropped
+                .write_closed
                 .store(true, Ordering::Release);
             self.worker_notifier.notify_one();
             Poll::Ready(Ok(()))

--- a/crates/ombrac-server/Cargo.toml
+++ b/crates/ombrac-server/Cargo.toml
@@ -66,7 +66,7 @@ bincode = { workspace = true }
 futures = { workspace = true }
 arc-swap = { workspace = true }
 thiserror = { workspace = true }
-rand = { workspace = true }
+rand = { workspace = true, features = ["thread_rng"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 clap = { workspace = true, features = ["std", "derive", "color", "help", "usage", "error-context", "suggestions"] }


### PR DESCRIPTION
Add a `write_closed` flag to `SharedState` so that `poll_shutdown` triggers `socket.close()` (FIN) rather than `socket.abort()` (RST). The `socket_dropped` flag (set by `Drop`) continues to call `abort()` for forced teardown, preserving correct half-close semantics.

Fixes #332