### PR TITLE
fix(server): improve DNS resolution and clean-close logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benches"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "bytes",
  "criterion",
@@ -1880,7 +1880,7 @@ dependencies = [
 
 [[package]]
 name = "ombrac"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "bincode",
  "bytes",
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "ombrac-client"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -1927,14 +1927,14 @@ dependencies = [
 
 [[package]]
 name = "ombrac-macros"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "ombrac-netstack"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "bytes",
  "crossbeam-queue",
@@ -1950,7 +1950,7 @@ dependencies = [
 
 [[package]]
 name = "ombrac-server"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "ombrac-transport"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "blake3",
  "bytes",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "tests-support"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "bytes",
  "ombrac-transport",

--- a/crates/ombrac-server/src/connection/dns.rs
+++ b/crates/ombrac-server/src/connection/dns.rs
@@ -1,7 +1,9 @@
 use std::io;
 use std::net::SocketAddr;
 
+use hickory_resolver::proto::rr::{RData, RecordType};
 use hickory_resolver::TokioResolver;
+use ombrac_macros::debug;
 use tokio::sync::OnceCell;
 
 // Global DNS resolver instance using hickory-resolver
@@ -46,25 +48,48 @@ pub(crate) async fn resolve_domain(domain: &[u8], port: u16) -> io::Result<Socke
         )
     })?;
 
-    let resolver = get_dns_resolver().await?;
-    let lookup_result = resolver.lookup_ip(domain_str).await.map_err(|e| {
-        io::Error::new(
-            io::ErrorKind::NotFound,
-            format!("dns resolution failed for {}: {}", domain_str, e),
-        )
-    })?;
+    // If the input is already an IP literal, return it directly without DNS lookup
+    if let Ok(ip) = domain_str.parse::<std::net::IpAddr>() {
+        return Ok(SocketAddr::new(ip, port));
+    }
 
-    // Get the first IP address (hickory-resolver returns addresses in preferred order)
-    lookup_result
-        .iter()
-        .next()
-        .map(|ip| SocketAddr::new(ip, port))
-        .ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::NotFound,
-                format!("no ip addresses found for {}", domain_str),
-            )
-        })
+    let resolver = get_dns_resolver().await?;
+
+    // Try IPv6 lookup first (RFC 6724 default preference).
+    // If IPv6 fails (common for domains without AAAA records), fall back to IPv4.
+    match resolver.lookup(domain_str, RecordType::AAAA).await {
+        Ok(lookup) => {
+            for record in lookup.answers() {
+                if let RData::AAAA(ipv6) = record.data {
+                    return Ok(SocketAddr::new(std::net::IpAddr::V6(ipv6.0), port));
+                }
+            }
+            debug!("ipv6 lookup for {} returned no AAAA records, trying ipv4", domain_str);
+        }
+        Err(e) => {
+            debug!("ipv6 lookup for {} failed: {}, trying ipv4", domain_str, e);
+        }
+    }
+
+    // Fall back to IPv4
+    match resolver.lookup(domain_str, RecordType::A).await {
+        Ok(lookup) => {
+            for record in lookup.answers() {
+                if let RData::A(ipv4) = record.data {
+                    return Ok(SocketAddr::new(std::net::IpAddr::V4(ipv4.0), port));
+                }
+            }
+            debug!("ipv4 lookup for {} returned no A records", domain_str);
+        }
+        Err(e) => {
+            debug!("ipv4 lookup for {} failed: {}", domain_str, e);
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        format!("dns resolution failed for {}: no records found", domain_str),
+    ))
 }
 
 #[cfg(test)]

--- a/crates/ombrac-server/src/connection/stream.rs
+++ b/crates/ombrac-server/src/connection/stream.rs
@@ -15,9 +15,9 @@ use tracing::Instrument;
 
 use ombrac::metrics::Metrics;
 use ombrac::{codec, protocol};
-use ombrac_macros::info;
+use ombrac_macros::{debug, info};
 use ombrac_transport::Connection;
-use ombrac_transport::io::{CopyBidirectionalStats, copy_bidirectional};
+use ombrac_transport::io::{CopyBidirectionalStats, copy_bidirectional, is_clean_stream_close};
 
 use crate::connection::dns;
 
@@ -297,13 +297,34 @@ impl Drop for StreamGuard {
                 .map(|s| (s.a_to_b_bytes, s.b_to_a_bytes))
                 .unwrap_or_default();
 
-            info!(
-                dest = %self.destination.as_ref().map(|a| a.to_string()).unwrap_or_else(|| "unknown".to_string()),
-                up = up + self.initial_upstream_bytes,
-                down,
-                duration = self.created_at.elapsed().as_millis(),
-                reason = %DisconnectReason(&self.reason),
-            );
+            let reason = DisconnectReason(&self.reason);
+            let dest = self
+                .destination
+                .as_ref()
+                .map(|a| a.to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            let up = up + self.initial_upstream_bytes;
+            let duration = self.created_at.elapsed().as_millis();
+
+            // Clean peer closes are expected; log at debug to reduce noise.
+            // Real errors remain at info level for operational visibility.
+            if reason.is_clean_peer_close() {
+                debug!(
+                    dest = %dest,
+                    up,
+                    down,
+                    duration,
+                    reason = %reason,
+                );
+            } else {
+                info!(
+                    dest = %dest,
+                    up,
+                    down,
+                    duration,
+                    reason = %reason,
+                );
+            }
         }
     }
 }
@@ -314,8 +335,22 @@ pub(crate) struct DisconnectReason<'a>(pub(crate) &'a Option<io::Error>);
 impl std::fmt::Display for DisconnectReason<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.0 {
+            Some(e) if is_clean_stream_close(e) => {
+                write!(f, "peer closed stream")
+            }
             Some(e) => write!(f, "{}", e),
             None => write!(f, "ok"),
+        }
+    }
+}
+
+impl DisconnectReason<'_> {
+    /// Returns true when the reason is a clean peer-initiated stream close
+    /// (quinn STOP_SENDING with error code 0 = "no error" per RFC 9000).
+    fn is_clean_peer_close(&self) -> bool {
+        match self.0 {
+            Some(e) => is_clean_stream_close(e),
+            None => true,
         }
     }
 }

--- a/crates/ombrac-transport/src/io.rs
+++ b/crates/ombrac-transport/src/io.rs
@@ -119,8 +119,8 @@ where
 ///
 /// The check works by downcasting the inner error source to [`quinn::WriteError`]
 /// rather than string-matching, so it is robust across quinn message format changes.
-#[cfg(feature = "quic")]
 pub fn is_clean_stream_close(error: &io::Error) -> bool {
+    #[cfg(feature = "quic")]
     if let Some(inner) = error.get_ref() {
         if let Some(write_err) = inner.downcast_ref::<quinn::WriteError>() {
             return matches!(write_err, quinn::WriteError::Stopped(code) if *code == quinn::VarInt::from(0u32));

--- a/crates/ombrac-transport/src/io.rs
+++ b/crates/ombrac-transport/src/io.rs
@@ -112,6 +112,23 @@ where
     Ok(stats)
 }
 
+/// Returns `true` when the error is a clean peer-initiated stream close —
+/// namely a QUIC `STOP_SENDING` frame with application error code 0 ("no error"
+/// per RFC 9000). These are expected during normal operation and should be
+/// logged at a lower severity than genuine transport errors.
+///
+/// The check works by downcasting the inner error source to [`quinn::WriteError`]
+/// rather than string-matching, so it is robust across quinn message format changes.
+#[cfg(feature = "quic")]
+pub fn is_clean_stream_close(error: &io::Error) -> bool {
+    if let Some(inner) = error.get_ref() {
+        if let Some(write_err) = inner.downcast_ref::<quinn::WriteError>() {
+            return matches!(write_err, quinn::WriteError::Stopped(code) if *code == quinn::VarInt::from(0u32));
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
- Use independent IPv4/IPv6 lookups instead of combined lookup_ip() so domains without AAAA records resolve successfully via their A records.  Prefer IPv6 per RFC 6724, fall back to IPv4 when AAAA lookup returns no records.
- Classify QUIC STOP_SENDING(0) as a clean peer close via downcast to quinn::WriteError instead of string-matching, and log it at debug level (not info) to reduce noise in production logs.