### PR TITLE
chore(ci): apply Windows MSVC fix to release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,20 @@ jobs:
           choco install nasm
           echo "C:\Program Files\NASM" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      - name: Setup MSVC environment for Windows
+        if: startsWith(matrix.os, 'windows')
+        shell: pwsh
+        run: |
+          $arch = if ("${{ matrix.target }}" -eq "aarch64-pc-windows-msvc") { "amd64_arm64" } else { "amd64" }
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsPath = & $vswhere -latest -property installationPath
+          $vcvars = Join-Path $vsPath "VC\Auxiliary\Build\vcvarsall.bat"
+          cmd /c "`"$vcvars`" $arch && set" | ForEach-Object {
+            if ($_ -match "^([^=]+)=(.*)$") {
+              "$($matches[1])=$($matches[2])" | Out-File -Append -FilePath $env:GITHUB_ENV
+            }
+          }
+
       - name: Install general dependencies for Ubuntu
         if: startsWith(matrix.os, 'ubuntu')
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,31 @@ jobs:
           choco install nasm
           echo "C:\Program Files\NASM" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      - name: Setup MSVC environment for Windows
+        if: startsWith(matrix.os, 'windows')
+        shell: pwsh
+        run: |
+          $arch = if ("${{ matrix.target }}" -eq "aarch64-pc-windows-msvc") { "amd64_arm64" } else { "amd64" }
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsPath = & $vswhere -latest -property installationPath
+          $vcvars = Join-Path $vsPath "VC\Auxiliary\Build\vcvarsall.bat"
+          cmd /c "`"$vcvars`" $arch && set" | ForEach-Object {
+            if ($_ -match "^([^=]+)=(.*)$") {
+              "$($matches[1])=$($matches[2])" | Out-File -Append -FilePath $env:GITHUB_ENV
+            }
+          }
+          $vsMajor = [int]((& $vswhere -latest -property installationVersion).Split('.')[0])
+          $cmakeExe = Join-Path $vsPath "Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe"
+          $helpOutput = & $cmakeExe --help 2>&1 | Out-String
+          if ($helpOutput -match "Visual Studio $vsMajor (\d{4})") {
+            $generator = "Visual Studio $vsMajor $($matches[1])"
+            "CMAKE_GENERATOR=$generator" | Out-File -Append -FilePath $env:GITHUB_ENV
+            Write-Host "Using CMake generator: $generator"
+          } else {
+            Write-Error "Could not detect Visual Studio $vsMajor cmake generator"
+            exit 1
+          }
+
       - name: Install general dependencies for Ubuntu
         if: startsWith(matrix.os, 'ubuntu')
         run: |


### PR DESCRIPTION
## Summary

- Apply the same Windows MSVC environment setup fix from #434 to `release.yml`
- The `windows-2025-vs2026` runner ships VS 18 which `cmake-rs 0.1.54` cannot auto-detect, causing build failures
- Fix: run `vcvarsall.bat` to set up MSVC env vars, then dynamically detect the VS generator name via `cmake --help` and export `CMAKE_GENERATOR`

## Test plan

- [x] Verify Windows release builds pass for both `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc`